### PR TITLE
fix: 补充安装typescript的描述

### DIFF
--- a/手写可插拔前端框架小册/1-2.牛刀小试-实现并发布一个CLI.md
+++ b/手写可插拔前端框架小册/1-2.牛刀小试-实现并发布一个CLI.md
@@ -28,8 +28,11 @@ npm i pnpm -g // 全局安装 pnpm
 
 优秀的`类型提示`可以给使用者极佳的体验
 
+以下两种安装方式选择其一即可
+
 ```js
-npm i typescript -d //我个人比较喜欢全局安装
+npm i typescript -d // 局部安装
+npm i typescript -g //我个人比较喜欢全局安装
 ```
 
 ### 创建项目
@@ -66,8 +69,11 @@ pnpm init //初始化并自动生成package.json
 
 ### 生成 tsconfig.json
 
+根据不同的安装方式使用对应的初始化命令
+
 ```js
-tsc --init
+npm tsc --init // 局部安装的初始化命令
+tsc --init // 全局安装的初始化命令
 ```
 
 ### 创建 src/index.ts


### PR DESCRIPTION
 `npm i typescript -g` 时可以通过`tsc --init`初始化，但如果是局部安装typescript（即 `npm i typescript -d`），初始化命令应为`npm tsc --init`，否则会报以下错误：
<img width="392" alt="image" src="https://github.com/BoyYangzai/mini-umi/assets/111556482/5c21766b-d759-4947-8e88-001adf73ff64">

